### PR TITLE
Add navigation helpers for secondary WeChat panels

### DIFF
--- a/wxauto4/ui/navigationbox.py
+++ b/wxauto4/ui/navigationbox.py
@@ -40,8 +40,24 @@ class NavigationBox:
     def switch_to_files_page(self):
         self.files_icon.Click()
 
-    def switch_to_files_page(self):
-        self.files_icon.Click()
-
     def switch_to_browser_page(self):
         self.browser_icon.Click()
+
+    def switch_to_moments_page(self):
+        self.moments_icon.Click()
+
+    def switch_to_video_page(self):
+        self.video_icon.Click()
+
+    def switch_to_stories_page(self):
+        self.stories_icon.Click()
+
+    def switch_to_mini_program_page(self):
+        self.mini_program_icon.Click()
+
+    def switch_to_phone_page(self):
+        self.phone_icon.Click()
+
+    def switch_to_settings_page(self):
+        self.settings_icon.Click()
+

--- a/wxauto4/wx.py
+++ b/wxauto4/wx.py
@@ -364,6 +364,43 @@ class WeChat(Chat, Listener):
         """切换到联系人页面"""
         self._api._navigation_api.contact_icon.Click()
 
+    def SwitchToFavorites(self) -> None:
+        """切换到收藏页面"""
+        self._api._navigation_api.switch_to_favorites_page()
+
+    def SwitchToFiles(self) -> None:
+        """切换到聊天文件页面"""
+        self._api._navigation_api.switch_to_files_page()
+
+    def SwitchToMoments(self) -> None:
+        """切换到朋友圈页面"""
+        self._api._navigation_api.switch_to_moments_page()
+
+    def SwitchToBrowser(self) -> None:
+        """切换到搜一搜页面"""
+        self._api._navigation_api.switch_to_browser_page()
+
+    def SwitchToVideo(self) -> None:
+        """切换到视频号页面"""
+        self._api._navigation_api.switch_to_video_page()
+
+    def SwitchToStories(self) -> None:
+        """切换到看一看页面"""
+        self._api._navigation_api.switch_to_stories_page()
+
+    def SwitchToMiniProgram(self) -> None:
+        """切换到小程序面板页面"""
+        self._api._navigation_api.switch_to_mini_program_page()
+
+    def SwitchToPhone(self) -> None:
+        """切换到手机页面"""
+        self._api._navigation_api.switch_to_phone_page()
+
+    def SwitchToSettings(self) -> None:
+        """切换到更多设置页面"""
+        self._api._navigation_api.switch_to_settings_page()
+
     def ShutDown(self):
         delete_update_files()
         os.system(f'taskkill /f /pid {self._api.pid}')
+


### PR DESCRIPTION
## Summary
- expose navigation box controls for favorites, files, moments, search, video, stories, mini program, phone, and settings
- add WeChat class helpers that route to the new navigation box methods

## Testing
- python -m compileall wxauto4/ui/navigationbox.py wxauto4/wx.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1719c784832a9888af3debb356a2